### PR TITLE
Jb/linear invariants

### DIFF
--- a/src/PDSProblemLibrary.jl
+++ b/src/PDSProblemLibrary.jl
@@ -32,7 +32,7 @@ There is one independent linear invariant, e.g. ``u_1+u_2 = 1``.
   [DOI: 10.1016/S0168-9274(03)00101-6](https://doi.org/10.1016/S0168-9274(03)00101-6)
 """
 prob_pds_linmod = ConservativePDSProblem(P_linmod, u0_linmod, (0.0, 2.0),
-                                         analytic = f_linmod_analytic, std_rhs = f_linmod)
+                                         analytic = f_linmod_analytic, std_rhs = f_linmod, lin_invariants = [1.0 1.0])
 
 function P_linmod!(P, u, p, t)
     P .= P_linmod(u, p, t)

--- a/src/PDSProblemLibrary.jl
+++ b/src/PDSProblemLibrary.jl
@@ -32,7 +32,8 @@ There is one independent linear invariant, e.g. ``u_1+u_2 = 1``.
   [DOI: 10.1016/S0168-9274(03)00101-6](https://doi.org/10.1016/S0168-9274(03)00101-6)
 """
 prob_pds_linmod = ConservativePDSProblem(P_linmod, u0_linmod, (0.0, 2.0),
-                                         analytic = f_linmod_analytic, std_rhs = f_linmod, lin_invariants = [1.0 1.0])
+                                         analytic = f_linmod_analytic, std_rhs = f_linmod,
+                                         lin_invariants = [1.0 1.0])
 
 function P_linmod!(P, u, p, t)
     P .= P_linmod(u, p, t)

--- a/src/proddest.jl
+++ b/src/proddest.jl
@@ -132,8 +132,12 @@ function PDSFunction{iip, FullSpecialize}(P, D;
     end
     PDSFunction{iip, FullSpecialize, typeof(P), typeof(D), typeof(p_prototype),
                 typeof(d_prototype),
-                typeof(std_rhs), typeof(analytic), typeof(lin_invariants)}(P, D, p_prototype, d_prototype, std_rhs,
-                                                   analytic, lin_invariants)
+                typeof(std_rhs), typeof(analytic), typeof(lin_invariants)}(P, D,
+                                                                           p_prototype,
+                                                                           d_prototype,
+                                                                           std_rhs,
+                                                                           analytic,
+                                                                           lin_invariants)
 end
 
 # Evaluation of a PDSFunction
@@ -318,8 +322,11 @@ function ConservativePDSFunction{iip, FullSpecialize}(P;
         std_rhs = ConservativePDSStdRHS(P, p_prototype)
     end
     ConservativePDSFunction{iip, FullSpecialize, typeof(P), typeof(p_prototype),
-                            typeof(std_rhs), typeof(analytic), typeof(lin_invariants)}(P, p_prototype, std_rhs,
-                                                               analytic, lin_invariants)
+                            typeof(std_rhs), typeof(analytic), typeof(lin_invariants)}(P,
+                                                                                       p_prototype,
+                                                                                       std_rhs,
+                                                                                       analytic,
+                                                                                       lin_invariants)
 end
 
 # Evaluation of a ConservativePDSFunction


### PR DESCRIPTION
We added the field `"lin_invariants"` to the structs `PDSFunction` and `PDSProblem` (as well as `ConservativePDSFunction/Problem`) to pass linear invariants to a problem. This is needed for the Sandu optimizer.

Based on that, we began to add the corresponding linear invariants to each test problem.
 