### PR TITLE
import ODESolution from SciMLBase instead of OrdinaryDiffEqCore

### DIFF
--- a/src/PositiveIntegrators.jl
+++ b/src/PositiveIntegrators.jl
@@ -16,10 +16,10 @@ using Reexport: @reexport
 @reexport using SciMLBase: ODEProblem, init, solve
 
 using SciMLBase: AbstractODEFunction, NullParameters, FullSpecialize,
-                 isinplace
+                 isinplace, ODESolution
 
 # TODO: Check imports and using statements below, reduce if possible
-using OrdinaryDiffEqCore: OrdinaryDiffEqCore, OrdinaryDiffEqAlgorithm, ODESolution
+using OrdinaryDiffEqCore: OrdinaryDiffEqCore, OrdinaryDiffEqAlgorithm
 
 using SymbolicIndexingInterface: SymbolicIndexingInterface
 


### PR DESCRIPTION
Heads-up about an upstream change plus a fix — no action needed on your released version.

## What will break

`OrdinaryDiffEqCore` on SciML master (v4.14.0, not yet registered) removed its blanket `@reexport using SciMLBase` in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4119. That dropped 152 names from `OrdinaryDiffEqCore`'s namespace without a major version bump, and `ODESolution` is one of them.

`PositiveIntegrators` reaches `ODESolution` through `OrdinaryDiffEqCore`, and the compat entry `OrdinaryDiffEqCore = "4.2"` admits 4.14.0, so `using PositiveIntegrators` fails once that version is registered:

```
WARNING: Imported binding OrdinaryDiffEqCore.ODESolution was undeclared at import time during import to PositiveIntegrators.
ERROR: LoadError: UndefVarError: `ODESolution` not defined in `PositiveIntegrators`
Suggestion: this global was defined as `OrdinaryDiffEqCore.ODESolution` but not assigned a value.
Hint: a global variable of this name also exists in SciMLBase.
Stacktrace:
  [1] top-level scope
    @ ~/PositiveIntegrators.jl/src/utilities.jl:30
```

The released v0.2.18 is covered separately by a retroactive registry cap (https://github.com/JuliaRegistries/General/pull/163935), so existing users are protected either way and there is no time pressure here. This PR is just so a future release keeps working.

## What this changes

`ODESolution` is owned and exported by `SciMLBase`, which is already a direct dependency. The import moves there; nothing else changes.

```diff
 using SciMLBase: AbstractODEFunction, NullParameters, FullSpecialize,
-                 isinplace
+                 isinplace, ODESolution

 # TODO: Check imports and using statements below, reduce if possible
-using OrdinaryDiffEqCore: OrdinaryDiffEqCore, OrdinaryDiffEqAlgorithm, ODESolution
+using OrdinaryDiffEqCore: OrdinaryDiffEqCore, OrdinaryDiffEqAlgorithm
```

No `Project.toml` change is needed: `SciMLBase` is already in `[deps]`, and the existing floor is enough — on `SciMLBase` v3.7.0, `Base.ispublic(SciMLBase, :ODESolution)` is `true`.

`ODESolution` is the only affected name. I checked every name the package pulls from `OrdinaryDiffEqCore` against v4.14.0; all the others (`OrdinaryDiffEqAlgorithm`, `OrdinaryDiffEqAdaptiveAlgorithm`, `OrdinaryDiffEqConstantCache`, `OrdinaryDiffEqMutableCache`, `_vec`, `alg_order`, `isfsal`, `calculate_residuals`, `calculate_residuals!`, `alg_cache`, `get_tmp_cache`, `initialize!`, `perform_step!`, `_ode_interpolant`, `_ode_interpolant!`, `get_fsalfirstlast`, `set_EEst!`, and `step!` used in the tests) are still defined there.

## Verification

Julia 1.12.6, this branch.

**1. Current registered `OrdinaryDiffEqCore` v4.13.0 — full test suite passes**

```
Test Summary:                |   Pass   Total       Time
PositiveIntegrators.jl tests | 125374  125374  106m00.1s
     Testing PositiveIntegrators tests passed
```

**2. `OrdinaryDiffEqCore` v4.14.0 (SciML master) — loads, and full test suite passes**

```
Test Summary:                |   Pass   Total       Time
PositiveIntegrators.jl tests | 125374  125374  107m27.5s
     Testing PositiveIntegrators tests passed
```

**3. Without this change, against v4.14.0** — the load error quoted above.

## What I did not verify

For run (2) I had to `dev` the master versions of `OrdinaryDiffEqLowOrderRK`, `OrdinaryDiffEqTsit5` and `OrdinaryDiffEqVerner` alongside `OrdinaryDiffEqCore`. That is not about this package: the registered `OrdinaryDiffEqLowOrderRK` v2.2.2 is itself broken against `OrdinaryDiffEqCore` v4.14.0 (`invalid method definition in OrdinaryDiffEqLowOrderRK: exported function OrdinaryDiffEqCore.u_cache does not exist`), so the test environment could not even precompile. That is https://github.com/SciML/OrdinaryDiffEq.jl/issues/4175 and is being fixed on the SciML side. `OrdinaryDiffEqRosenbrock` and `OrdinaryDiffEqSDIRK` at their registered versions were fine against 4.14.0.

I could not test against a fully released ecosystem at `OrdinaryDiffEqCore` 4.14.0 because that version is not registered yet. I also did not build the docs.

`JuliaFormatter` v1.0.60 with your `.JuliaFormatter.toml` reports no changes.

## Links

- Upstream change: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4119
- Analysis of the fallout: https://github.com/SciML/OrdinaryDiffEq.jl/issues/4175
- Retroactive cap protecting v0.2.18: https://github.com/JuliaRegistries/General/pull/163935
