### PR TITLE
Extend Base.isnegative on Julia 1.13+ to fix export ambiguity

### DIFF
--- a/src/PositiveIntegrators.jl
+++ b/src/PositiveIntegrators.jl
@@ -39,6 +39,13 @@ import OrdinaryDiffEqCore: alg_order, isfsal,
 
 using RecipesBase: @recipe
 
+# `isnegative` is exported by Base since Julia 1.13
+# (https://github.com/JuliaLang/julia/pull/53677); extend it there to avoid
+# exporting a second, ambiguous binding.
+if isdefined(Base, :isnegative)
+    import Base: isnegative
+end
+
 # 2. Export functionality defining the public API
 export PDSFunction, PDSProblem
 export ConservativePDSFunction, ConservativePDSProblem

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -237,9 +237,16 @@ end
             else
                 persistent_tasks = true
             end
+            # `isnegative` is part of Base since Julia 1.13, but
+            # PositiveIntegrators extends it with methods for vectors
+            # and ODE solutions.
+            treat_as_own = Function[RecipesBase.apply_recipe]
+            if isdefined(Base, :isnegative)
+                push!(treat_as_own, Base.isnegative)
+            end
             Aqua.test_all(PositiveIntegrators;
                           ambiguities = ambiguities,
-                          piracies = (; treat_as_own = [RecipesBase.apply_recipe],),
+                          piracies = (; treat_as_own = treat_as_own),
                           persistent_tasks = persistent_tasks)
         end
     end


### PR DESCRIPTION
## Summary

Julia 1.13 newly exports `Base.isnegative`/`Base.ispositive` ([JuliaLang/julia#53677](https://github.com/JuliaLang/julia/pull/53677)). PositiveIntegrators.jl defines and exports its own `isnegative`, so on Julia 1.13 the name becomes an ambiguous export: after `using PositiveIntegrators`, every unqualified `isnegative(...)` errors with

```
UndefVarError: `isnegative` not defined in `Main`
Hint: It looks like two or more modules export different bindings with this name ...
```

This was surfaced by OrdinaryDiffEq.jl's IntegrationTest workflow (`GROUP=Downstream`), which runs this package's test suite against OrdinaryDiffEq master on Julia 1.13 — every test using `isoutofdomain = isnegative` or `isnegative(sol)` errored.

**Fix:** on Julia >= 1.13, `import Base: isnegative` in `src/PositiveIntegrators.jl`, so the package *extends* the Base function instead of exporting a competing binding. `using PositiveIntegrators` then re-exports the single `Base.isnegative` binding and unqualified uses work again. The package's methods (`AbstractVector`, `AbstractVector{<:AbstractVector}`, `ODESolution`) are a natural generalization of the Base predicate (`x < 0` for `Real` → "does the state/solution contain a negative entry"), so extending is semantically correct; scalar calls still dispatch to the Base methods. On Julia < 1.13 (`isdefined(Base, :isnegative) === false`, e.g. the 1.10 LTS) the package keeps defining its own function — no behavior change.

This also fixes `JuMPExt`, which does `using PositiveIntegrators` and calls `isnegative(u)` internally (used by the `SanduProjection` callback).

Since the extension methods apply to foreign types (`AbstractVector`, `SciMLBase.ODESolution`), Aqua flags them as type piracy on Julia 1.13, so `Base.isnegative` is added to the Aqua `treat_as_own` list conditionally in `test/runtests.jl`.

## Test plan

**Before fix, Julia 1.13.0-rc4** (`julia +1.13 --project=test`):

```
julia> isnegative(sol_Euler)
ERROR: UndefVarError: `isnegative` not defined in `Main`
Hint: It looks like two or more modules export different bindings with this name, resulting in ambiguity. ...
Test Summary:   | Error  Total  Time
is(non)negative |     1      1  6.5s
```

**After fix, Julia 1.13.0-rc4** — all testsets exercising `isnegative`/`isnonnegative` pass:

```
Test Summary:      | Pass  Total   Time
Aqua.jl            |   10     10  33.0s
ExplicitImports.jl |    2      2  16.3s
Check that production-destruction form and standard ODE fit together in predefinded problems | 49  49  8m32s
Sandu projection   |    9      9  30.6s
is(non)negative    |    8      8   3.7s
Check that the predefined linear invariant matrices fit in predefined problems               | 10  10   7.0s
```

Sanity checks on 1.13: `isnegative([1.0, -2.0]) === true`, `isnegative([1.0, 2.0]) === false`, `isnegative(-1.0) === true`, `isnegative(1.0) === false`, `parentmodule(isnegative) === Base`; `solve(prob, alg; isoutofdomain = isnegative)` produces results identical to the PDS/std_rhs formulations.

**Julia 1.10.11** (`julia +1.10 --project=test`, same extracted testsets) — unchanged behavior, `parentmodule(isnegative) === PositiveIntegrators`:

```
Test Summary:      | Pass  Total   Time
Aqua.jl            |   10     10  33.4s
ExplicitImports.jl |    2      2   3.2s
Check that production-destruction form and standard ODE fit together in predefinded problems | 49  49  7m22s
Sandu projection   |    9      9  26.5s
is(non)negative    |    8      8   4.5s
Check that the predefined linear invariant matrices fit in predefined problems               | 10  10   6.7s
```

Formatting checked with JuliaFormatter 1.0.60 (sciml style, as in `FormatCheck.yml`): both changed files already conform. `typos` clean over the diff. The full `Pkg.test()` suite was not run end-to-end locally (it is a single multi-hour testset); the extracted testsets above cover every `isnegative`/`isnonnegative` use site in `test/runtests.jl` plus Aqua and ExplicitImports.

🤖 Generated with [Devin](https://devin.ai) (harness: Devin CLI 3000.10.21, model: SWE-2 High). Session: local Devin CLI session (no shareable URL); session db at /home/crackauc/.local/share/devin/cli/sessions.db
